### PR TITLE
NUnit 3.12.0

### DIFF
--- a/nuget/NUnitTestOrdering.nuspec
+++ b/nuget/NUnitTestOrdering.nuspec
@@ -20,7 +20,7 @@
 		
 		<dependencies>
 			<!-- Since we rely on some details on how NUnit functions, lets keep it limited to minor versions. -->
-			<dependency id="NUnit" version="[3.7, 3.8)" />
+			<dependency id="NUnit" version="[3.7, 3.9)" />
 		</dependencies>
 	</metadata>
 	<files>

--- a/src/NUnitTestOrdering.Tests/Support/NUnitTestVersions/packages.config
+++ b/src/NUnitTestOrdering.Tests/Support/NUnitTestVersions/packages.config
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
+    <package id="NUnit" version="3.8.1"/>
+    <package id="NUnit" version="3.8.0"/>
     <package id="NUnit" version="3.7.1"/>
     <package id="NUnit" version="3.7.0"/>
     


### PR DESCRIPTION
Rebuild  NUnitTestOrdering.dll  with  NUnit 3.12.0.0 dependency, 17 sept. 2020.

[NUnit 3.12.0.0 NUnitTestOrdering.zip](https://github.com/Sebazzz/NUnitTestOrdering/files/5239872/NUnit.3.12.0.0.NUnitTestOrdering.zip)
